### PR TITLE
Fix generator checkout in the repository stats workflow

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: ""
+      generator-ref:
+        description: Ref of trsdn/.github holding the generator to run.
+        required: false
+        type: string
+        default: main
     secrets:
       STATS_TOKEN:
         description: Optional token for private repositories or higher API limits.
@@ -61,7 +66,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: trsdn/.github
-          ref: ${{ github.action_ref || 'main' }}
+          ref: ${{ inputs.generator-ref }}
           token: ${{ secrets.STATS_TOKEN || github.token }}
           path: stats-source
       - name: Set up Python

--- a/docs/repo-stats.md
+++ b/docs/repo-stats.md
@@ -17,7 +17,13 @@ name: Repository stats
 on:
   workflow_dispatch:
   schedule:
-    - cron: "23 */6 * * *"
+    - cron: "23 5 * * *"
+  push:
+    branches:
+      # Change this if the repository's default branch is not `main`.
+      - main
+    paths:
+      - .github/workflows/stats.yml
 
 permissions:
   contents: write
@@ -32,6 +38,10 @@ jobs:
     secrets:
       STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
 ```
+
+Adjust the `push` branch filter to the repository's default branch. The
+`schedule` and `workflow_dispatch` triggers only ever run on the default branch,
+so a workflow that has not been merged there yet cannot be dispatched.
 
 For public repositories, the caller repository `GITHUB_TOKEN` is usually enough.
 For private repositories or higher API limits, create a fine-grained PAT and

--- a/templates/repo-stats/stats.yml
+++ b/templates/repo-stats/stats.yml
@@ -6,6 +6,7 @@ on:
     - cron: "23 5 * * *"
   push:
     branches:
+      # Change this if the repository's default branch is not `main`.
       - main
     paths:
       - .github/workflows/stats.yml


### PR DESCRIPTION
The reusable workflow resolved the generator ref with `github.action_ref`, which in a reusable workflow holds the SHA of the last action that ran, not a ref of this repository. The first run against `trsdn/OpenLens` failed with `upload-pack: not our ref 3d3c42e5...`, the pinned `actions/checkout` SHA.

Replaces it with an explicit `generator-ref` input defaulting to `main`.

Also documents that the caller template's `push` branch filter has to match the repository's default branch; `OpenLens` uses `master` and would never have triggered on push.