### PR TITLE
Allow agents to tag and publish releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,15 @@ the suite goes red. A test that passes either way is not coverage.
   the same change.
 - **Regenerate, do not edit.** After changing the standard, run
   `python3 scripts/standard.py` and commit the regenerated `standard.yml`.
-- **Version and changelog move together.** Adding criteria is a minor bump;
-  removing, renumbering, or narrowing a criterion is a major bump. The check
-  enforces that the document version matches the newest changelog entry.
+- **Version and changelog move together.** The bump follows
+  [Versioning And Compatibility](docs/repository-quality-standard.md#versioning-and-compatibility),
+  which is the only place the rules are stated. The check enforces that the
+  document version matches the newest changelog entry.
+- **Publish the release when the version changes.** Tag the commit that carries
+  the new version as `v<version>` and push the tag. The release workflow verifies
+  that the tag, `standard.yml`, and the changelog agree, then publishes with the
+  changelog entry as the notes. A version that is never tagged cannot be cited by
+  pinned reference, which is the whole point of versioning this document.
 - **Every criterion needs evidence a single maintainer can produce.** Do not add
   a criterion requiring a paid tool, an audit, a certification, or a specialist.
 - **Do not require tooling that does not exist** in the repositories being
@@ -108,9 +114,8 @@ ecosystem, or build tool.
   standard requires this of assessed repositories in `B13`, and this repository
   is not exempt from its own criteria. Generated restatement is fine, because it
   cannot drift; hand-maintained restatement is not.
-- Do not create or move Git tags, publish releases, or change repository
-  settings, branch protection, or security settings. Those are maintainer
-  actions.
+- Do not change repository settings, branch protection, or security settings.
+  Those are maintainer actions.
 - Do not hand-edit `standard.yml` or anything under `.github/badges/`.
 - Do not change a conformance record to make a badge look better. The record
   follows the evidence; the badge follows the record.


### PR DESCRIPTION
Tagging and releasing were listed as maintainer actions in `AGENTS.md`. Per
maintainer instruction they are not, so the restriction is removed.

The guard was never in *who* runs the release: `.github/workflows/release.yml`
already verifies that the tag, `standard.yml`, and the changelog agree, and
refuses to publish when they do not. The rule only ensured that three versions —
`1.4.0`, `1.5.0`, `1.5.1` — sat untagged, which defeats the point of versioning
a document whose criteria are cited by pinned reference.

Replaced with positive guidance: tag `v<version>`, push, the workflow does the
rest and takes its notes from the changelog.

## Also: the bump rules had already drifted

The versioning bullet restated the policy — "adding criteria is a minor bump;
removing, renumbering, or narrowing a criterion is a major bump" — and that was
already wrong. `1.5.0` added a fourth row for narrowing a profile's
applicability, and this copy never learned about it.

One day old, and exactly the failure `B13` describes: the stale copy still reads
as authoritative. It now links to
[Versioning And Compatibility](https://github.com/trsdn/.github/blob/main/docs/repository-quality-standard.md#versioning-and-compatibility)
and keeps only the fact that is local to this repository — that a check enforces
it.

The three missing releases will be published once this merges.