### PR TITLE
Record that a criterion is decided by its rule text alone, and check the tag it names

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -28,6 +28,22 @@ jobs:
       - name: Verify record and badge
         run: python3 scripts/conformance.py --check
 
+  tagged:
+    name: Recorded version is tagged
+    # Only on the default branch. A version bump is merged before its tag
+    # exists, so requiring the tag on the pull request would block every bump.
+    # Between the merge and the tag this job is red, which is the point: the
+    # recorded version is one no repository can be assessed against yet.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository with tags
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify the recorded standard version has a published tag
+        run: python3 scripts/conformance.py --check --published-tags "$(git tag --list)"
+
   tests:
     name: Script tests
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,17 @@ the suite goes red. A test that passes either way is not coverage.
 
 ## Rules specific to the standard
 
+- **A criterion is decided by its rule text alone.** Before merging a criterion
+  or a rule that feeds one, take it and a plausible repository and try to reach
+  `Pass`, `Partial`, `Fail`, or `Not applicable` using only the document at that
+  version. If that needs an intention the text does not state, the text is not
+  finished. Every case a rule names has a stated result, and so does everything
+  its enumeration excludes; attach the outcome to a property of the thing
+  assessed rather than to a residual set like "everywhere else"; say that a
+  permission is a permission, because `may` beside a list reads as `must`; and
+  never let the changelog carry the rule. See
+  [decision 0011](docs/decisions/0011-criteria-are-decided-by-the-rule-text.md),
+  which exists because `P08` failed this twice in consecutive versions.
 - **Criterion identifiers are append-only.** Never renumber, reuse, or repurpose
   an identifier. A retired criterion keeps its identifier and gains a retirement
   note. Identifiers are cited from other repositories and from issues; changing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,13 @@ record has aged past the review cadence. A red check from ageing is intentional
 and means reassessment is due. Regenerating the badge makes it render as stale
 but does not clear the check, because only a fresh assessment can.
 
+Adding `--published-tags` makes it also fail when the recorded
+`standard_version` has no tag. CI supplies it on the default branch only, since
+a version bump is merged before it is tagged; between the merge and the tag that
+job is red, and tagging clears it. It is deliberately absent from the local
+validation list for the same reason: on a branch that bumps the version, the tag
+cannot exist yet.
+
 `scripts/links.py` fails when a relative link points at a file that does not
 exist, or at a heading or `<a id>` anchor that does not. Anchors are the reason
 it exists: criteria are cited from other repositories as `#s05`, and renaming a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,11 @@ the suite goes red. A test that passes either way is not coverage.
   the new version as `v<version>` and push the tag. The release workflow verifies
   that the tag, `standard.yml`, and the changelog agree, then publishes with the
   changelog entry as the notes. A version that is never tagged cannot be cited by
-  pinned reference, which is the whole point of versioning this document.
+  pinned reference, which is the whole point of versioning this document. Until
+  the tag exists no repository can be assessed against that version, and this
+  repository's own record must not name it: `standard_version` must be a
+  published tag, and the local check cannot see when it is not. See
+  [decision 0011](docs/decisions/0011-criteria-are-decided-by-the-rule-text.md).
 - **Every criterion needs evidence a single maintainer can produce.** Do not add
   a criterion requiring a paid tool, an audit, a certification, or a specialist.
 - **Do not require tooling that does not exist** in the repositories being

--- a/docs/decisions/0011-criteria-are-decided-by-the-rule-text.md
+++ b/docs/decisions/0011-criteria-are-decided-by-the-rule-text.md
@@ -1,0 +1,84 @@
+# 0011 - A criterion is decided by its rule text alone
+
+- Status: Accepted
+- Date: 2026-08-31
+
+## Context
+
+`P08` failed twice in a row, in two consecutive versions, for the same reason.
+Both failures surfaced only when someone actually assessed a repository against
+the criterion, and neither was visible while writing it.
+
+In 1.5.1 the badge rule asked for images served from a first-party source
+"where practical". The first repository assessed against it recorded `Partial`
+and wrote that there was no work available that would clear the criterion. That
+was correct: "where practical" names no condition a repository can satisfy, so
+the criterion had no reachable `Pass`. A qualifier had been used to cover a case
+the author had not decided.
+
+1.6.0 replaced that qualifier with a rule that turns on how a value changes, and
+introduced a second hole of a different shape. One bullet named license,
+platform, and conformance as qualifying for a committed image; the next granted
+a `Pass` to a live third-party image "everywhere else". The three named values
+were not "everywhere else", so the text left them with no stated result — not
+`Pass`, not `Partial`, not `Fail` — which allowed "may be committed" to be read
+as "must be committed". The assessor found both readings, could not settle them
+against the document, and settled them against a sentence in the changelog:
+"No recorded result can turn into a `Fail` from any of this."
+
+That sentence produced the right answer. It is still the failure. A conformance
+record cites a version of the standard, and the reusable check validates against
+the document at that tag. A changelog entry is not part of what a later reader
+retrieves when they ask what a criterion required, so a result that depends on
+one cannot be reproduced from the evidence the record names. The 1.6.1 wording
+fix closed the specific hole; it did not stop the next one.
+
+The two holes look different and share a cause. "Where practical" defers a
+decision to the assessor. A residual set — "everywhere else" — defers it to
+whoever compares two lists and notices which members fall outside both. In each
+case the rule described a preference and left the outcome to be inferred.
+
+## Decision
+
+A criterion is decided by the text of the standard at the version being assessed,
+and by nothing else.
+
+Concretely, before a criterion or a rule that feeds one is merged:
+
+- Every case the rule names has a stated result. If a rule enumerates values,
+  cases, or exceptions, each one resolves to `Pass`, `Partial`, `Fail`, or
+  `Not applicable`, and so does everything the enumeration excludes.
+- Outcomes attach to a property of the thing assessed, not to a residual set.
+  "A value with no first-party image" survives someone extending a list later;
+  "everywhere else" does not.
+- A permission says it is a permission. Where a rule allows something without
+  requiring it, the text says so, because `may` next to an enumeration reads as
+  `must` to the next person.
+- Where a criterion has a reachable `Pass`, the work that reaches it is
+  identifiable from the text. A criterion no repository can clear is a defect,
+  not a high bar.
+- The changelog explains why a rule changed. It never carries the rule. If the
+  changelog entry is needed to decide a result, the rule is not finished.
+
+The rules that follow from this live in `AGENTS.md`, where they are read before
+a change rather than after one.
+
+## Consequences
+
+This is a drafting rule, not a criterion. It adds nothing to assess and does not
+change any recorded result. It is enforced by review, because no script can tell
+a rule that decides a case from one that merely discusses it.
+
+The check that makes it usable is cheap: take the criterion and a plausible
+repository, and try to reach a result using only the document at that version. If
+that requires an intention the text does not state, the text is not finished.
+Both `P08` failures would have been caught by doing this with a licence badge in
+hand, which is why the rule is stated as an act of assessment rather than as
+advice to write clearly.
+
+It also sets an expectation for how this kind of defect is reported. Both `P08`
+holes were found by an assessor who checked the rule instead of adopting a
+conclusion, and both were fixed in the standard rather than absorbed into a
+repository's record as a `Partial` nobody could clear. An assessment that cannot
+reach a result from the text is evidence about the standard, and the standard is
+where it goes.

--- a/docs/decisions/0011-criteria-are-decided-by-the-rule-text.md
+++ b/docs/decisions/0011-criteria-are-decided-by-the-rule-text.md
@@ -63,11 +63,43 @@ Concretely, before a criterion or a rule that feeds one is merged:
 The rules that follow from this live in `AGENTS.md`, where they are read before
 a change rather than after one.
 
+## A rule this repository cannot violate visibly is untested here
+
+The same failure has a second form, found while this decision was being written.
+
+`docs/conformance-record.md` states that `standard_version` "must be a published
+tag". Two versions were merged to `main` without being tagged, and the record in
+this repository was updated to name one of them. For several hours the repository
+that defines the rule was the repository breaking it, and every check stayed
+green.
+
+Nothing was misconfigured. This repository validates its own record with
+`scripts/conformance.py --check` against the catalog in its own checkout.
+Consuming repositories validate through the reusable workflow, which checks the
+standard out at `v<standard_version>` from the record. Those are two code paths,
+and only the first runs here. The one that resolves a tag — the only one that can
+notice a tag is missing — never runs against this repository, so the rule was
+structurally unfalsifiable at home while a consumer with the identical record
+would have failed hard at checkout.
+
+This is the drafting failure moved down a layer. There, a rule described a
+preference and left the outcome to be inferred. Here, a check appears to enforce
+a rule it cannot reach.
+
+A rule that cannot be violated visibly in the repository that defines it is
+untested in that repository, and publishing it does not make it true locally.
+When this repository asserts something about how consumers are validated, it
+exercises the consumer path or accepts that the assertion is unverified. Where
+the state can only go wrong between a merge and a follow-up action, a red check
+on the default branch is the right instrument, not a stricter pull-request gate:
+`scripts/conformance.py --check` already turns red as a record ages, because a
+red check that means "a maintainer action is due" is an established signal here.
+
 ## Consequences
 
 This is a drafting rule, not a criterion. It adds nothing to assess and does not
-change any recorded result. It is enforced by review, because no script can tell
-a rule that decides a case from one that merely discusses it.
+change any recorded result. The first half is enforced by review, because no
+script can tell a rule that decides a case from one that merely discusses it.
 
 The check that makes it usable is cheap: take the criterion and a plausible
 repository, and try to reach a result using only the document at that version. If
@@ -76,9 +108,15 @@ Both `P08` failures would have been caught by doing this with a licence badge in
 hand, which is why the rule is stated as an act of assessment rather than as
 advice to write clearly.
 
-It also sets an expectation for how this kind of defect is reported. Both `P08`
-holes were found by an assessor who checked the rule instead of adopting a
-conclusion, and both were fixed in the standard rather than absorbed into a
-repository's record as a `Partial` nobody could clear. An assessment that cannot
-reach a result from the text is evidence about the standard, and the standard is
-where it goes.
+The second half is not a review rule and should not stay one. A missing tag is
+mechanically detectable, and leaving it to review is the same mistake in a
+smaller font. Until a check on the default branch fails when the recorded
+`standard_version` resolves to no published tag, this repository is relying on
+someone noticing, which is what it just failed to do.
+
+It also sets an expectation for how both defects were reported. Both `P08` holes
+and the untagged record were found by an assessor who checked the rule instead of
+adopting a conclusion, and each was fixed at its source rather than absorbed into
+a repository's record as a `Partial` nobody could clear. An assessment that
+cannot reach a result from the text, or a green check that cannot see a
+violation, is evidence about the standard, and the standard is where it goes.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,4 +16,4 @@ future reader can see why it is the way it is before changing it.
 | [0008](0008-internal-links-are-checked-external-links-are-not.md) | Internal links and anchors are checked in CI; external links are deliberately not | Accepted |
 | [0009](0009-published-sites-and-content-boundaries.md) | Published sites carry the shared design language, and each fact has one home | Accepted |
 | [0010](0010-release-notes-come-from-the-changelog.md) | Release notes are generated from the changelog, and `R06` stays as it is | Accepted |
-| [0011](0011-criteria-are-decided-by-the-rule-text.md) | A criterion is decided by its rule text alone, never by the changelog | Accepted |
+| [0011](0011-criteria-are-decided-by-the-rule-text.md) | A criterion is decided by its rule text alone, and a rule this repository cannot violate visibly is untested here | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,3 +16,4 @@ future reader can see why it is the way it is before changing it.
 | [0008](0008-internal-links-are-checked-external-links-are-not.md) | Internal links and anchors are checked in CI; external links are deliberately not | Accepted |
 | [0009](0009-published-sites-and-content-boundaries.md) | Published sites carry the shared design language, and each fact has one home | Accepted |
 | [0010](0010-release-notes-come-from-the-changelog.md) | Release notes are generated from the changelog, and `R06` stays as it is | Accepted |
+| [0011](0011-criteria-are-decided-by-the-rule-text.md) | A criterion is decided by its rule text alone, never by the changelog | Accepted |

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -9,9 +9,16 @@ A record older than the review cadence renders as stale rather than as its last
 known result. Because the badge is committed, time passing eventually turns the
 check red. That is intentional: a red check means reassessment is due.
 
+A record names the standard version it was assessed against, and a consuming
+repository resolves that version at its tag. Passing `--published-tags` asserts
+that the tag exists. It is omitted on pull requests, because a version bump is
+merged before it is tagged, and supplied on the default branch, where an
+untagged version means the tag is overdue.
+
 Usage:
     python3 scripts/conformance.py            # write the badge
     python3 scripts/conformance.py --check    # verify, exit non-zero on drift
+    python3 scripts/conformance.py --check --published-tags "$(git tag --list)"
 """
 
 from __future__ import annotations
@@ -81,7 +88,10 @@ def parse_record(text: str) -> tuple[dict, dict[str, str], list[str]]:
 
 
 def validate(
-    scalars: dict, criteria: dict[str, str], catalog: pathlib.Path
+    scalars: dict,
+    criteria: dict[str, str],
+    catalog: pathlib.Path,
+    published_tags: set[str] | None = None,
 ) -> tuple[list[str], bool]:
     errors: list[str] = []
 
@@ -116,6 +126,14 @@ def validate(
             f"record assesses standard `{scalars.get('standard_version')}` but the "
             f"catalog in this repository is `{catalog_version}`; reassess or pin "
             "the record to a published tag of that version"
+        )
+
+    version = scalars.get("standard_version", "")
+    if published_tags is not None and version and f"v{version}" not in published_tags:
+        errors.append(
+            f"record names standard `{version}`, but `v{version}` is not a published "
+            "tag; a repository assessed against it resolves the standard at that tag "
+            "and cannot check it out, so tag the commit carrying the version"
         )
 
     for identifier, result in sorted(criteria.items()):
@@ -180,7 +198,19 @@ def main() -> int:
         type=pathlib.Path,
         help="criteria catalog to validate against; defaults to the repository's own standard.yml",
     )
+    parser.add_argument(
+        "--published-tags",
+        help=(
+            "the tags that exist, separated by whitespace or commas; when given, the "
+            "recorded standard version must have one. Omit it and the check is skipped, "
+            "because a version bump is merged before its tag exists"
+        ),
+    )
     arguments = parser.parse_args()
+
+    published_tags = None
+    if arguments.published_tags is not None:
+        published_tags = {tag for tag in arguments.published_tags.replace(",", " ").split()}
 
     repository = arguments.repository.resolve()
     record_path = repository / DEFAULT_RECORD
@@ -202,7 +232,7 @@ def main() -> int:
 
     scalars, criteria, errors = parse_record(record_path.read_text())
     if not errors:
-        validation_errors, stale = validate(scalars, criteria, catalog_path)
+        validation_errors, stale = validate(scalars, criteria, catalog_path, published_tags)
         errors.extend(validation_errors)
     else:
         stale = False

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -154,6 +154,38 @@ class ConformanceTests(ScriptTestCase):
         self.write_record(record(version="1.0.0"))
         self.assertRejects(self.check(), "reassess or pin the record")
 
+    # Published tags --------------------------------------------------------
+
+    def test_accepts_a_recorded_version_that_has_a_published_tag(self) -> None:
+        self.write_record(record())
+        self.generate_badge()
+        self.assertAccepts(
+            self.run_script("conformance.py", "--check", "--published-tags", "v1.9.0, v2.0.0")
+        )
+
+    def test_rejects_a_recorded_version_that_has_no_published_tag(self) -> None:
+        """The state this repository was in: merged, recorded, never tagged."""
+        self.write_record(record())
+        self.generate_badge()
+        self.assertRejects(
+            self.run_script("conformance.py", "--check", "--published-tags", "v1.9.0"),
+            "`v2.0.0` is not a published tag",
+        )
+
+    def test_rejects_a_recorded_version_when_no_tag_exists_at_all(self) -> None:
+        self.write_record(record())
+        self.generate_badge()
+        self.assertRejects(
+            self.run_script("conformance.py", "--check", "--published-tags", ""),
+            "`v2.0.0` is not a published tag",
+        )
+
+    def test_skips_the_tag_check_when_no_tags_are_supplied(self) -> None:
+        """A version bump is merged before it is tagged, so pull requests opt out."""
+        self.write_record(record())
+        self.generate_badge()
+        self.assertAccepts(self.check())
+
     # Ageing ----------------------------------------------------------------
 
     def test_rejects_a_record_older_than_the_review_cadence(self) -> None:


### PR DESCRIPTION
## Problem

`P08` failed twice in consecutive versions, and both failures surfaced only when someone actually assessed a repository against it.

- **1.5.1** asked for first-party badge images "where practical". [trsdn/PtionsPlus#33](https://github.com/trsdn/PtionsPlus/pull/33) recorded `Partial` and wrote that no work was available that would clear it. That was correct — the qualifier named no condition a repository could satisfy, so the criterion had no reachable `Pass`.
- **1.6.0** replaced it with a rule that turns on how a value changes, and opened a hole of a different shape. One bullet named licence, platform, and conformance as qualifying for a committed image; the next granted a `Pass` to a live third-party image "everywhere else". The three named values are not "everywhere else", so they had no stated result at all, and `may be committed` could be read as `must`. The assessor found both readings, could not settle them against the document, and settled them against a changelog sentence: *"No recorded result can turn into a `Fail` from any of this."*

That sentence produced the right answer. It is still the failure. A conformance record cites a version, and the reusable check validates against the document **at that tag**. A changelog entry is not part of what a later reader retrieves, so a result that depends on one cannot be reproduced from the evidence the record names.

The two holes share a cause: "where practical" defers the decision to the assessor, a residual set defers it to whoever notices which members fall outside both lists. Each described a preference and left the outcome to be inferred.

### The same failure one layer down

While this was being written, `main` carried two untagged versions and this repository's own record named one of them. `docs/conformance-record.md` says `standard_version` "must be a published tag", so the repository defining the rule was the one breaking it — and every check stayed green.

Nothing was misconfigured. This repository validates its record against the catalog in its own checkout; consumers validate through the reusable workflow, which checks the standard out at `v<standard_version>`. Only the first path runs here, and it is the one that cannot notice a missing tag. A consumer with the identical record would have failed hard at checkout.

A rule that cannot be violated visibly in the repository that defines it is untested in that repository.

## Change

**Decision 0011** — `docs/decisions/0011-criteria-are-decided-by-the-rule-text.md`, with the evidence from all three incidents and the rules that follow: every named case and everything its enumeration excludes has a stated result; outcomes attach to a property of the thing assessed, not to a residual set; a permission says it is a permission; a reachable `Pass` names the work that reaches it; the changelog explains why a rule changed and never carries the rule.

**`AGENTS.md`** — the drafting rule at the top of *Rules specific to the standard*, and the tagging consequence added to the release rule, so both are read before a change rather than after one.

**The missing check** — `scripts/conformance.py --published-tags` fails when the recorded `standard_version` has no tag, wired into `.github/workflows/standard.yml` as a job that runs **on the default branch only**. A version bump is merged before it is tagged, so requiring the tag on the pull request would block every bump. Between merge and tag the job is red, which is the accurate state: the recorded version is one no repository can be assessed against yet. That mirrors the existing ageing check, where red already means a maintainer action is due.

Four tests cover it — accepted when the tag exists, rejected when it does not, rejected when no tag exists at all, skipped when no tags are supplied. Disabling the condition turns the two rejection tests red, per `AGENTS.md`.

## Scope

No criterion changes and no recorded result moves, so the standard version is untouched and no changelog entry is due.

`v1.6.1` and `v1.7.0` have been tagged and released separately, so this repository's own record (`standard_version: "1.7.0"`) now names a published tag and the new job passes on `main` from the start.

## Verification

```text
python3 scripts/standard.py --check                                    # 94 criteria, catalog in sync
python3 scripts/conformance.py --check                                 # Healthy (na=39, pass=55), badge in sync
python3 scripts/conformance.py --check --published-tags "$(git tag --list)"
python3 scripts/links.py                                               # links resolve across 28 Markdown files
python3 -m unittest discover -s tests                                  # 75 tests, OK
npx markdownlint-cli2@0.18.1 "**/*.md"                                 # 0 errors
ruff==0.14.5 check . && ruff==0.14.5 format --check .                  # clean
```
