### PR TITLE
docs: say who tags a release and when an agent may

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,19 +106,42 @@ the suite goes red. A test that passes either way is not coverage.
   [Versioning And Compatibility](docs/repository-quality-standard.md#versioning-and-compatibility),
   which is the only place the rules are stated. The check enforces that the
   document version matches the newest changelog entry.
-- **Publish the release when the version changes.** Tag the commit that carries
-  the new version as `v<version>` and push the tag. The release workflow verifies
-  that the tag, `standard.yml`, and the changelog agree, then publishes with the
-  changelog entry as the notes. A version that is never tagged cannot be cited by
-  pinned reference, which is the whole point of versioning this document. Until
-  the tag exists no repository can be assessed against that version, and this
+- **Publish the release when the version changes.** The commit that carries the
+  new version is tagged `v<version>` on the default branch, after the pull
+  request that bumped it has merged. The release workflow verifies that the tag,
+  `standard.yml`, and the changelog agree, then publishes with the changelog
+  entry as the notes. A version that is never tagged cannot be cited by pinned
+  reference, which is the whole point of versioning this document. Until the tag
+  exists no repository can be assessed against that version, and this
   repository's own record must not name it: `standard_version` must be a
   published tag, and the local check cannot see when it is not. See
   [decision 0011](docs/decisions/0011-criteria-are-decided-by-the-rule-text.md).
+- **Tagging is a maintainer action, and an agent does not take it unasked.** See
+  [Releasing and publishing](#releasing-and-publishing) for who tags, when, and
+  what an agent may do when it is asked to.
 - **Every criterion needs evidence a single maintainer can produce.** Do not add
   a criterion requiring a paid tool, an audit, a certification, or a specialist.
 - **Do not require tooling that does not exist** in the repositories being
   assessed.
+
+## Releasing and publishing
+
+By default an agent does not release. The tag belongs on a merge commit that
+does not exist while the bump is still in review, so an agent cannot create it
+from the branch that bumps the version. An agent that bumps the version says in
+the pull request that the tag is outstanding, and stops there.
+
+If a maintainer explicitly instructs an agent, in the current request, to create
+and push the release tag once the bump has merged, the agent may do so. Verify
+first that the version in `standard.yml` and the matching `CHANGELOG.md` entry
+already agree with the requested tag, since
+[`.github/workflows/release.yml`](.github/workflows/release.yml) rejects the tag
+otherwise.
+
+Do not invoke `gh release create` yourself even under such an instruction.
+Pushing the tag is sufficient: the workflow verifies the tag against
+`standard.yml`, refuses a changelog that still holds entries in an unreleased
+section, extracts the notes for that version, and publishes.
 
 ## Rules specific to the inherited community files
 
@@ -138,6 +161,9 @@ ecosystem, or build tool.
   cannot drift; hand-maintained restatement is not.
 - Do not change repository settings, branch protection, or security settings.
   Those are maintainer actions.
+- Do not create or move a tag, publish a release, or push to the default branch
+  unless a maintainer explicitly instructs you to in the current request, and
+  then only as described in [Releasing and publishing](#releasing-and-publishing).
 - Do not hand-edit `standard.yml` or anything under `.github/badges/`.
 - Do not change a conformance record to make a badge look better. The record
   follows the evidence; the badge follows the record.


### PR DESCRIPTION
## Why

`AGENTS.md` told an agent to *"Tag the commit that carries the new version as `v<version>` and push the tag."* Three surfaces disagreed about whether that was allowed:

| Surface | Said |
|---|---|
| `AGENTS.md` (rules section) | Tag it and push the tag |
| `templates/AGENTS.md:74` (the published `G03` baseline) | "Do not deploy, publish a release, create or move tags" |
| `AGENTS.md` "Do not do these" | Silent on tagging |

The instruction was also unsatisfiable at the point it was read. The tag belongs on a merge commit that does not exist while the bump is still in review, and `AGENTS.md` states that no change is pushed straight to the default branch — so an agent could not create it from the branch that bumps the version. With no stated result, agents stalled on version bumps.

This is `docs/decisions/0011` applied to `AGENTS.md` itself: the rule needed an intention the text did not state.

## What changed

Name the actor rather than loosen the requirement. `AGENTS.md` only:

- The release bullet now says the tag lands on the default branch *after the bump's pull request merges*, and drops the instruction to the agent to do it.
- A new **Releasing and publishing** section states the default (an agent does not release, and says in the pull request that the tag is outstanding), the exception (a maintainer may explicitly instruct an agent, in the current request, to create and push the tag once the bump has merged), the verification to perform first, and the line the exception does not cross — pushing the tag is sufficient, so `gh release create` stays with `.github/workflows/release.yml`.
- The "Do not do these" list gains a matching entry pointing at that section.

The exception is written as a permission, not a requirement, per the `may`-beside-a-list guidance in decision 0011. This mirrors the pattern already in use in `trsdn/agent-trestle`.

Nothing about the requirement itself changed: an untagged version still cannot be cited by pinned reference, and `standard_version` still must name a published tag.

## Not changed

- No criteria added, renumbered, or repurposed.
- `standard.yml` and `.github/badges/` untouched; no regeneration needed.
- No standard version bump — this edits repository operating rules, not the standard.
- `templates/AGENTS.md` left as is; its `[State who does, and how.]` placeholder already asks each repository to name its own actor, which is exactly what this change does here.

## Validation

All commands from [Validation](README.md#validation) pass:

```
standard: 94 criteria, catalog in sync
conformance: Healthy (na=39, pass=55), badge in sync
internal links resolve across 28 Markdown files
Ran 75 tests in 15.295s — OK
markdownlint-cli2: 28 file(s), 0 error(s)
```