### PR TITLE
feat: draft a conformance record from what a script can read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ statistics cards.
 | `templates/AGENTS.md` | Starting point published for other repositories. |
 | `templates/conformance.yml` | Generated starting point for a conformance record. Never hand-edit. |
 | `scripts/standard.py`, `scripts/conformance.py`, `scripts/links.py` | Validation and generation tooling for the standard, Python standard library only. |
+| `scripts/assess.py` | Drafts a conformance record for another repository from what the GitHub API exposes. Standard library only; see [assessing](docs/assessing.md). |
 | `scripts/profile_stats/` | Self-hosted GitHub statistics generator; runtime dependency is `requests`. |
 | `tests/` | Tests for the tooling in `scripts/`, run via `unittest`. |
 | `.github/conformance.yml` | This repository's conformance record. |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,17 @@ its meaning. See
 
 ## Applying the standard to a repository
 
-1. Assess the repository against a published version of the standard.
+1. Assess the repository against a published version of the standard. To start
+   from a draft rather than a blank record, read what a script can read:
+
+   ```sh
+   python3 scripts/assess.py --repo owner/name --out drafts/owner-name
+   ```
+
+   It decides only the criteria a fact settles — the topic, the licence, the
+   `permissions` blocks, the action references — and leaves everything that
+   turns on judgement `unknown`. See [drafting a record](docs/assessing.md).
+
 2. Record the result in `.github/conformance.yml`, following the
    [record format](docs/conformance-record.md). To start from a record that
    already names every criterion, copy
@@ -69,7 +79,8 @@ gh search repos --owner trsdn --topic trsdn-standard --limit 100 \
 ```
 
 The difference between that list and the full account list is the outstanding
-assessment backlog.
+assessment backlog. [`scripts/assess.py`](docs/assessing.md) exists to make that
+number movable.
 
 ## This repository's own result
 
@@ -143,9 +154,10 @@ npx --yes markdownlint-cli2@0.18.1 "**/*.md"
 pipx run ruff==0.14.5 check . && pipx run ruff==0.14.5 format --check .
 ```
 
-The standard and conformance scripts, the link checker, and their tests use the
-Python standard library only. The statistics generator is separate runtime
-tooling and installs `requests` from `requirements.txt` when its workflows run.
+The standard and conformance scripts, the link checker, the draft assessor, and
+their tests use the Python standard library only. The statistics generator is
+separate runtime tooling and installs `requests` from `requirements.txt` when
+its workflows run.
 Markdown linting and Ruff pin their tool versions and are never added as
 dependencies, so every script still runs from a bare Python installation.
 

--- a/docs/assessing.md
+++ b/docs/assessing.md
@@ -1,0 +1,89 @@
+# Drafting a conformance record
+
+`scripts/assess.py` reads a repository through the GitHub API and writes a draft
+conformance record plus the notes behind it. It exists because the backlog is
+arithmetic: `B12` makes the assessed set discoverable, and the difference
+between that set and the account is the work outstanding. Transcribing a hundred
+records by hand is what keeps that number from moving.
+
+## What it will and will not decide
+
+A script can prove that something is absent. It cannot judge whether a README
+explains the purpose, whether tests cover failure paths, or whether an issue
+form collects enough to triage on. So it decides only the criteria that a fact
+settles, and leaves every other criterion `unknown`.
+
+`unknown` is not a result. `scripts/conformance.py --check` rejects a record
+containing one, and the draft keeps the `YYYY-MM-DD` placeholder in
+`assessed_on`, which the same check also rejects. Both are deliberate. A record
+is produced by a person looking at a repository, and a generated file must not
+be able to pass for one. The script removes the transcription, not the
+assessment.
+
+| Criterion | Decided from |
+|---|---|
+| `B01` | The repository description, and only when it is empty |
+| `B03`, `P01` | The licence GitHub detects, against the OSI-approved list |
+| `B09` | The archived flag, and only when the repository is archived |
+| `B11` | Whether `.github/conformance.yml` exists |
+| `B12` | Whether the `trsdn-standard` topic is present |
+| `P02`, `P06` | The community profile GitHub reports, which counts inherited files |
+| `P03` | A security policy in the tree or recognised by GitHub, absence only |
+| `P04`, `P10`, `P11` | Whether any intake template exists, absence only |
+| `S05` | The secret scanning status, where the token can see it |
+| `S09` | Required status checks on the default branch, where the token can see it |
+| `S11` | A `permissions` block in every workflow |
+| `S12` | Every `uses:` reference, against the graduated table in the standard |
+| `S13` | Untrusted triggers and the secrets they can reach |
+| `G01` | Whether `AGENTS.md` is at the root |
+
+Everything else is left to a person, and the notes file lists it.
+
+Two of these deserve their limits stated. `P10` and `P11` ask whether intake
+collects enough to act on, which the standard assesses on the information
+gathered rather than on headings; the script can only see that no template
+exists at all, so that is the only result it records. And `P03` is recorded as a
+failure only when no policy is found anywhere — the community profile API emits
+no `security` key, so its absence proves nothing.
+
+Where the repository is private, the Public profile does not apply, and the
+script records `na` against every `P` criterion with that reason.
+
+## Running it
+
+```sh
+python3 scripts/assess.py --repo owner/name
+python3 scripts/assess.py --repo owner/name --out drafts/owner-name
+```
+
+With `--out` it writes `conformance.yml` and `assessment.md` into that
+directory. Without it, the record goes to standard output.
+
+Authentication comes from `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`.
+An unauthenticated run still works against a public repository, but the security
+and branch-protection facts need a token that can read them, and criteria whose
+evidence is not visible are left `unknown` rather than guessed at.
+
+## Finishing the draft
+
+1. Work through the criteria the notes list as left to a person.
+2. Replace `assessed_on` with the date you did that.
+3. Set `state` from the [Assessment](repository-quality-standard.md#assessment)
+   rules, which assign it by impact rather than by percentage.
+4. Rewrite `assessment.md` as the evidence the record's `evidence` field points
+   at, and check the drafted results while you are there. They are derived from
+   one fact each and are not immune to being wrong.
+5. Run `python3 scripts/conformance.py --check` in the assessed repository.
+
+## Offline and repeatable runs
+
+Collection and decision are separate, so the decisions can be re-run without the
+network:
+
+```sh
+python3 scripts/assess.py --repo owner/name --save-facts facts.json
+python3 scripts/assess.py --facts facts.json
+```
+
+This is also how the tests exercise every rule, including the `S12` table, with
+no network access and no fixture repository.

--- a/scripts/assess.py
+++ b/scripts/assess.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Draft a conformance record for a repository from evidence a script can read.
+
+The backlog this exists for is arithmetic: `B12` makes the assessed set
+discoverable, and the difference between that set and the account is the work
+outstanding. Transcribing a hundred records by hand is what keeps that number
+from moving.
+
+What this script will and will not claim is the whole design. A script can prove
+that something is absent. It cannot judge whether a README explains the purpose,
+whether tests cover failure paths, or whether an issue form collects enough to
+triage. So it decides only the criteria that are settled by a fact it can read —
+a topic, a licence, a `permissions` block, an action reference — and leaves
+every other criterion `unknown`, which is not a result and is rejected by
+`conformance.py --check` until a person replaces it.
+
+The draft keeps the `YYYY-MM-DD` placeholder in `assessed_on` for the same
+reason. A record is produced by a person looking at a repository, and a
+generated file must not be able to pass for one. The draft removes the
+transcription, not the assessment.
+
+Collection is separated from decision so that the decisions are testable without
+a network: `--save-facts` writes what was read, and `--facts` decides from a
+saved file.
+
+Usage:
+    python3 scripts/assess.py --repo trsdn/agent-trestle
+    python3 scripts/assess.py --repo trsdn/agent-trestle --out drafts/
+    python3 scripts/assess.py --repo trsdn/agent-trestle --save-facts facts.json
+    python3 scripts/assess.py --facts facts.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import conformance  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_CATALOG = pathlib.Path("standard.yml")
+
+API = "https://api.github.com"
+TOPIC = "trsdn-standard"
+
+# Licences GitHub reports that the Open Source Initiative approves. GitHub's own
+# `license.spdx_id` is the input, so this list only has to cover what it emits
+# for the repositories being assessed; anything else is left undecided rather
+# than guessed at.
+OSI_APPROVED = {
+    "AGPL-3.0",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "EPL-2.0",
+    "GPL-2.0",
+    "GPL-3.0",
+    "ISC",
+    "LGPL-2.1",
+    "LGPL-3.0",
+    "MIT",
+    "MPL-2.0",
+    "Unlicense",
+    "Zlib",
+}
+
+WORKFLOW = re.compile(r"^\.github/workflows/[^/]+\.ya?ml$")
+ISSUE_FORM = re.compile(r"^\.github/ISSUE_TEMPLATE/[^/]+\.(ya?ml|md)$")
+PR_TEMPLATE = re.compile(
+    r"^(\.github/|docs/)?(pull_request_template\.md|PULL_REQUEST_TEMPLATE\.md)$"
+)
+USES = re.compile(r"^\s*(?:-\s*)?uses:\s*['\"]?([^'\"\s#]+)", re.M)
+PERMISSIONS = re.compile(r"^\s*permissions:", re.M)
+SHA = re.compile(r"^[0-9a-f]{40}$")
+UNTRUSTED_TRIGGER = re.compile(r"^\s*(pull_request_target|workflow_run)\s*:", re.M)
+SECRET_USE = re.compile(r"secrets\.([A-Za-z_][A-Za-z0-9_]*)")
+
+UNDECIDED = "unknown"
+
+
+def note(message: str) -> None:
+    print(f"assess: {message}", file=sys.stderr)
+
+
+# --------------------------------------------------------------------------
+# Collection
+# --------------------------------------------------------------------------
+
+
+def token() -> str | None:
+    """Find a token without requiring one to be exported by hand."""
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return None
+    return result.stdout.strip() or None
+
+
+class GitHub:
+    """The smallest client that answers the questions below."""
+
+    def __init__(self, auth: str | None) -> None:
+        self.auth = auth
+
+    def _get(self, path: str, accept: str) -> tuple[int, bytes]:
+        request = urllib.request.Request(f"{API}{path}")
+        request.add_header("Accept", accept)
+        request.add_header("User-Agent", "trsdn-standard-assessor")
+        if self.auth:
+            request.add_header("Authorization", f"Bearer {self.auth}")
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return response.status, response.read()
+        except urllib.error.HTTPError as error:
+            return error.code, b""
+        except urllib.error.URLError as error:
+            raise SystemExit(f"assess: cannot reach the GitHub API: {error.reason}") from error
+
+    def json(self, path: str) -> tuple[int, object]:
+        status, body = self._get(path, "application/vnd.github+json")
+        if status != 200 or not body:
+            return status, None
+        return status, json.loads(body)
+
+    def text(self, path: str) -> str | None:
+        status, body = self._get(path, "application/vnd.github.raw")
+        if status != 200:
+            return None
+        return body.decode("utf-8", errors="replace")
+
+
+def collect(client: GitHub, repository: str) -> dict:
+    """Read every fact the decisions below depend on, and nothing else."""
+    status, meta = client.json(f"/repos/{repository}")
+    if status == 404:
+        raise SystemExit(f"assess: {repository} was not found, or the token cannot see it")
+    if not isinstance(meta, dict):
+        raise SystemExit(f"assess: unexpected response for {repository} (HTTP {status})")
+
+    branch = meta.get("default_branch") or "main"
+    _, profile = client.json(f"/repos/{repository}/community/profile")
+    _, tree = client.json(f"/repos/{repository}/git/trees/{branch}?recursive=1")
+
+    paths: list[str] = []
+    if isinstance(tree, dict):
+        paths = [item["path"] for item in tree.get("tree", []) if item.get("type") == "blob"]
+
+    contents: dict[str, str] = {}
+    for path in paths:
+        if WORKFLOW.match(path) or ISSUE_FORM.match(path) or PR_TEMPLATE.match(path):
+            body = client.text(f"/repos/{repository}/contents/{path}?ref={branch}")
+            if body is not None:
+                contents[path] = body
+
+    protection_status, protection = client.json(f"/repos/{repository}/branches/{branch}/protection")
+    licence = meta.get("license") or {}
+    analysis = meta.get("security_and_analysis") or {}
+    files = (profile or {}).get("files") or {} if isinstance(profile, dict) else {}
+
+    return {
+        "repository": repository,
+        "collected_on": dt.date.today().isoformat(),
+        "owner": repository.split("/")[0],
+        "private": bool(meta.get("private")),
+        "archived": bool(meta.get("archived")),
+        "description": meta.get("description") or "",
+        "homepage": meta.get("homepage") or "",
+        "topics": meta.get("topics") or [],
+        "default_branch": branch,
+        "licence": licence.get("spdx_id") or "",
+        "truncated_tree": bool(tree.get("truncated")) if isinstance(tree, dict) else False,
+        "paths": paths,
+        "contents": contents,
+        "community_files": {key: bool(value) for key, value in files.items()},
+        "secret_scanning": (analysis.get("secret_scanning") or {}).get("status", ""),
+        "protection": {
+            "visible": protection_status == 200,
+            "required_checks": sorted(
+                ((protection or {}).get("required_status_checks") or {}).get("contexts", [])
+            )
+            if isinstance(protection, dict)
+            else [],
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# Decision
+# --------------------------------------------------------------------------
+
+
+def workflows(facts: dict) -> dict[str, str]:
+    return {path: body for path, body in facts["contents"].items() if WORKFLOW.match(path)}
+
+
+def reference_is_pinned(reference: str, owner: str) -> bool:
+    """Apply the `S12` table: the required form depends on who controls the target."""
+    if reference.startswith("./") or reference.startswith("docker://"):
+        return True
+    name, _, version = reference.partition("@")
+    account = name.split("/")[0].lower()
+    if account == owner.lower():
+        return True
+    if account == "actions" or account == "github":
+        return bool(version)
+    return bool(SHA.match(version))
+
+
+def decide_s11(facts: dict) -> tuple[str, str]:
+    found = workflows(facts)
+    if not found:
+        return "na", "no workflows exist, so there is no token to scope"
+    declared = [path for path, body in found.items() if PERMISSIONS.search(body)]
+    if len(declared) == len(found):
+        return "pass", f"all {len(found)} workflows declare `permissions`"
+    if not declared:
+        return "fail", f"none of the {len(found)} workflows declare `permissions`"
+    missing = sorted(set(found) - set(declared))
+    return (
+        "partial",
+        f"{len(declared)} of {len(found)} declare `permissions`; missing: " + ", ".join(missing),
+    )
+
+
+def decide_s12(facts: dict) -> tuple[str, str]:
+    found = workflows(facts)
+    if not found:
+        return "na", "no workflows exist, so there is no reference to pin"
+    unpinned: list[str] = []
+    total = 0
+    for path, body in found.items():
+        for reference in USES.findall(body):
+            total += 1
+            if not reference_is_pinned(reference, facts["owner"]):
+                unpinned.append(f"{path}: {reference}")
+    if not total:
+        return "na", "no workflow references an action or a reusable workflow"
+    if not unpinned:
+        return "pass", f"all {total} references satisfy the table"
+    return "fail", f"{len(unpinned)} of {total} references can move: " + ", ".join(sorted(unpinned))
+
+
+def decide_s13(facts: dict) -> tuple[str, str]:
+    found = workflows(facts)
+    exposed: list[str] = []
+    untrusted: list[str] = []
+    for path, body in found.items():
+        if not UNTRUSTED_TRIGGER.search(body):
+            continue
+        untrusted.append(path)
+        secrets = {name for name in SECRET_USE.findall(body) if name != "GITHUB_TOKEN"}
+        if secrets:
+            exposed.append(f"{path}: {', '.join(sorted(secrets))}")
+    if not untrusted:
+        return "na", "no workflow uses `pull_request_target` or `workflow_run`"
+    if exposed:
+        return "fail", "untrusted trigger reads repository secrets: " + ", ".join(sorted(exposed))
+    return "pass", "untrusted triggers exist but read no repository secret: " + ", ".join(
+        sorted(untrusted)
+    )
+
+
+def decide_licence(facts: dict) -> dict[str, tuple[str, str]]:
+    spdx = facts["licence"]
+    decided: dict[str, tuple[str, str]] = {}
+    if spdx and spdx not in {"NOASSERTION", "NONE"}:
+        decided["B03"] = ("pass", f"GitHub detects `{spdx}`")
+        if spdx in OSI_APPROVED:
+            decided["P01"] = ("pass", f"`{spdx}` is OSI approved")
+        else:
+            decided["P01"] = (UNDECIDED, f"`{spdx}` detected; confirm OSI approval by hand")
+        return decided
+    if facts["private"]:
+        decided["B03"] = (UNDECIDED, "no licence file; look for an internal-use statement")
+        return decided
+    decided["B03"] = ("fail", "public repository with no licence GitHub can detect")
+    decided["P01"] = ("fail", "no licence file")
+    return decided
+
+
+def decide(facts: dict, catalog_ids: list[str]) -> dict[str, tuple[str, str]]:
+    """Return only the results a fact settles. Everything else stays undecided."""
+    decided: dict[str, tuple[str, str]] = {}
+    paths = set(facts["paths"])
+    community = facts["community_files"]
+
+    decided["B12"] = (
+        ("pass", f"carries the `{TOPIC}` topic")
+        if TOPIC in facts["topics"]
+        else ("fail", f"the `{TOPIC}` topic is missing, so the repository is not discoverable")
+    )
+
+    record = ".github/conformance.yml"
+    decided["B11"] = (
+        ("pass", f"`{record}` exists")
+        if record in paths
+        else ("fail", f"no `{record}`, so no assessed version or date is recorded")
+    )
+
+    if not facts["description"]:
+        decided["B01"] = ("fail", "the repository has no description")
+
+    decided.update(decide_licence(facts))
+
+    decided["G01"] = (
+        ("pass", "`AGENTS.md` is at the repository root")
+        if "AGENTS.md" in paths
+        else ("fail", "no `AGENTS.md` at the root")
+    )
+
+    decided["S11"] = decide_s11(facts)
+    decided["S12"] = decide_s12(facts)
+    decided["S13"] = decide_s13(facts)
+
+    if facts["secret_scanning"] == "enabled":
+        decided["S05"] = ("pass", "secret scanning is enabled")
+    elif facts["secret_scanning"] == "disabled":
+        decided["S05"] = ("fail", "secret scanning is disabled")
+
+    if facts["protection"]["visible"]:
+        checks = facts["protection"]["required_checks"]
+        decided["S09"] = (
+            ("pass", "required checks on the default branch: " + ", ".join(checks))
+            if checks
+            else ("fail", "the default branch is protected but requires no check")
+        )
+
+    forms = [path for path in paths if ISSUE_FORM.match(path)]
+    template = [path for path in paths if PR_TEMPLATE.match(path)]
+    if not forms and not template:
+        decided["P04"] = ("fail", "no issue template and no pull-request template")
+        decided["P10"] = ("fail", "no issue template of any kind")
+        decided["P11"] = ("fail", "no pull-request template")
+    elif forms and template:
+        decided["P04"] = ("pass", "issue and pull-request templates are present")
+
+    if community:
+        expected = ("readme", "license", "contributing", "code_of_conduct")
+        missing = [name for name in expected if not community.get(name)]
+        decided["P02"] = (
+            ("pass", "contributing and conduct files are recognised by GitHub")
+            if not {"contributing", "code_of_conduct"} & set(missing)
+            else (
+                "fail",
+                "GitHub recognises no "
+                + " or ".join(sorted({"contributing", "code_of_conduct"} & set(missing))),
+            )
+        )
+        decided["P06"] = (
+            ("pass", "GitHub recognises every community health file")
+            if not missing
+            else ("partial", "GitHub recognises no " + ", ".join(missing))
+        )
+        if not community.get("security") and not any(
+            path.upper().endswith("SECURITY.MD") for path in paths
+        ):
+            decided["P03"] = (
+                "fail",
+                "no security policy in the tree and none recognised by GitHub",
+            )
+
+    if facts["archived"]:
+        decided["B09"] = ("pass", "the repository is archived, which is an intentional state")
+
+    if facts["private"]:
+        for identifier in catalog_ids:
+            if identifier.startswith("P"):
+                decided[identifier] = (
+                    "na",
+                    "the repository is private, so the Public profile does not apply",
+                )
+
+    return decided
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+def render_record(catalog: pathlib.Path, decided: dict[str, tuple[str, str]]) -> str:
+    """Fill the generated scaffold, so the criteria list cannot drift from the catalog."""
+    scaffold = conformance.scaffold(catalog)
+    lines = []
+    for line in scaffold.splitlines():
+        match = re.match(r"^  ([A-Z]\d{2}): unknown$", line)
+        if match and match.group(1) in decided:
+            lines.append(f"  {match.group(1)}: {decided[match.group(1)][0]}")
+        else:
+            lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def render_notes(facts: dict, decided: dict[str, tuple[str, str]], undecided: list[str]) -> str:
+    """Write the evidence the record has to point at."""
+    lines = [
+        f"# Draft assessment of {facts['repository']}",
+        "",
+        f"- Collected on: {facts['collected_on']}",
+        f"- Default branch: `{facts['default_branch']}`",
+        f"- Visibility: {'private' if facts['private'] else 'public'}",
+        "",
+        "This file is a draft. Every result below was decided by",
+        "`scripts/assess.py` from a fact it could read, and every other criterion",
+        "is still `unknown`. Finish the assessment by hand before the record is",
+        "worth anything: replace the remaining results, replace `assessed_on`,",
+        "and rewrite this file as the evidence a reader can check.",
+        "",
+        "## Decided from evidence",
+        "",
+        "| Criterion | Result | Evidence |",
+        "|---|---|---|",
+    ]
+    for identifier in sorted(decided):
+        result, why = decided[identifier]
+        if result == UNDECIDED:
+            continue
+        lines.append(f"| `{identifier}` | {result} | {why} |")
+
+    lines += [
+        "",
+        "## Left to a person",
+        "",
+        "These criteria turn on judgement a script cannot make — whether a README",
+        "explains the purpose, whether tests cover failure paths, whether an",
+        "intake form collects enough to act on. They remain `unknown`, which",
+        "`conformance.py --check` rejects until each one is replaced.",
+        "",
+        "`" + "`, `".join(undecided) + "`",
+        "",
+    ]
+    if facts["truncated_tree"]:
+        lines += [
+            "> The file listing was truncated by the API, so a path-based result",
+            "> may be wrong. Check by hand.",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="Repository as owner/name.")
+    parser.add_argument("--facts", help="Decide from a saved facts file instead of the API.")
+    parser.add_argument("--save-facts", help="Write the collected facts to this path.")
+    parser.add_argument("--out", help="Directory to write the draft record and notes into.")
+    parser.add_argument(
+        "--repository",
+        default=str(ROOT),
+        help="Repository holding the catalog. Defaults to this one.",
+    )
+    arguments = parser.parse_args()
+
+    if not arguments.repo and not arguments.facts:
+        note("give either --repo owner/name or --facts FILE")
+        return 2
+
+    catalog = pathlib.Path(arguments.repository) / DEFAULT_CATALOG
+    if not catalog.is_file():
+        note(f"no catalog at {catalog}")
+        return 1
+
+    if arguments.facts:
+        facts = json.loads(pathlib.Path(arguments.facts).read_text(encoding="utf-8"))
+    else:
+        facts = collect(GitHub(token()), arguments.repo)
+
+    if arguments.save_facts:
+        pathlib.Path(arguments.save_facts).write_text(
+            json.dumps(facts, indent=2) + "\n", encoding="utf-8"
+        )
+
+    catalog_ids = conformance.CATALOG_ID.findall(catalog.read_text(encoding="utf-8"))
+    decided = {
+        identifier: value
+        for identifier, value in decide(facts, catalog_ids).items()
+        if value[0] != UNDECIDED and identifier in catalog_ids
+    }
+    undecided = [identifier for identifier in catalog_ids if identifier not in decided]
+
+    record = render_record(catalog, decided)
+    notes = render_notes(facts, decided, undecided)
+
+    if arguments.out:
+        directory = pathlib.Path(arguments.out)
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "conformance.yml").write_text(record, encoding="utf-8")
+        (directory / "assessment.md").write_text(notes, encoding="utf-8")
+        note(f"wrote a draft record and notes to {directory}")
+    else:
+        print(record)
+
+    note(
+        f"decided {len(decided)} of {len(catalog_ids)} criteria; {len(undecided)} left to a person"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_assess.py
+++ b/tests/test_assess.py
@@ -1,0 +1,219 @@
+"""Tests for scripts/assess.py.
+
+The script exists to remove transcription from an assessment, not judgement. So
+these tests pin down both halves of that: the results it derives from a fact are
+correct, including the graduated `S12` table, and the results it cannot derive
+stay `unknown` in a draft that still cannot pass for an assessment.
+
+Every case runs the command line against a facts file, so no test touches the
+network and the contract asserted is the one a maintainer uses.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from support import ROOT, SCRIPTS
+
+
+def facts(**overrides) -> dict:
+    """A minimal, passing set of facts that each test bends into one shape."""
+    base = {
+        "repository": "trsdn/example",
+        "collected_on": "2026-01-01",
+        "owner": "trsdn",
+        "private": False,
+        "archived": False,
+        "description": "An example repository.",
+        "homepage": "",
+        "topics": ["trsdn-standard"],
+        "default_branch": "main",
+        "licence": "MIT",
+        "truncated_tree": False,
+        "paths": ["README.md", "AGENTS.md", ".github/conformance.yml"],
+        "contents": {},
+        "community_files": {},
+        "secret_scanning": "",
+        "protection": {"visible": False, "required_checks": []},
+    }
+    base.update(overrides)
+    return base
+
+
+def workflow(body: str, name: str = "ci.yml") -> dict:
+    return {f".github/workflows/{name}": body}
+
+
+class AssessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.directory = pathlib.Path(directory.name)
+
+    def assess(self, data: dict) -> tuple[dict[str, str], str]:
+        """Run the script and return the drafted results and the notes."""
+        source = self.directory / "facts.json"
+        source.write_text(json.dumps(data), encoding="utf-8")
+        out = self.directory / "out"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "assess.py"),
+                "--facts",
+                str(source),
+                "--out",
+                str(out),
+                "--repository",
+                str(ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"expected a zero exit. Output:\n{result.stdout}{result.stderr}",
+        )
+        record = (out / "conformance.yml").read_text(encoding="utf-8")
+        drafted = {}
+        for line in record.splitlines():
+            if line.startswith("  ") and ":" in line:
+                key, _, value = line.strip().partition(":")
+                drafted[key] = value.strip()
+        return drafted, (out / "assessment.md").read_text(encoding="utf-8")
+
+    # -- the draft must not be able to pass for an assessment ---------------
+
+    def test_the_draft_keeps_the_placeholder_date(self) -> None:
+        """A generated file must not read as a record a person produced."""
+        source = self.directory / "facts.json"
+        source.write_text(json.dumps(facts()), encoding="utf-8")
+        out = self.directory / "out"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "assess.py"),
+                "--facts",
+                str(source),
+                "--out",
+                str(out),
+                "--repository",
+                str(ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertIn('assessed_on: "YYYY-MM-DD"', (out / "conformance.yml").read_text())
+
+    def test_criteria_it_cannot_decide_stay_unknown(self) -> None:
+        drafted, notes = self.assess(facts())
+        self.assertEqual(drafted["B02"], "unknown", "a README's content is not machine-decidable")
+        self.assertEqual(drafted["S02"], "unknown", "test coverage is not machine-decidable")
+        self.assertIn("`B02`", notes.split("## Left to a person")[1])
+
+    # -- S12, whose table is the point ------------------------------------
+
+    def test_an_outside_action_referenced_by_tag_fails(self) -> None:
+        drafted, notes = self.assess(facts(contents=workflow("jobs:\n  uses: someone/act@v3\n")))
+        self.assertEqual(drafted["S12"], "fail")
+        self.assertIn("someone/act@v3", notes)
+
+    def test_an_outside_action_pinned_by_sha_passes(self) -> None:
+        reference = "someone/act@" + "a" * 40
+        drafted, _ = self.assess(facts(contents=workflow(f"jobs:\n  uses: {reference}\n")))
+        self.assertEqual(drafted["S12"], "pass")
+
+    def test_a_github_action_may_use_a_major_version_tag(self) -> None:
+        drafted, _ = self.assess(facts(contents=workflow("jobs:\n  uses: actions/checkout@v7\n")))
+        self.assertEqual(drafted["S12"], "pass")
+
+    def test_a_workflow_in_the_same_account_may_use_a_branch(self) -> None:
+        """The third row of the table is a permission, so the script must honour it."""
+        drafted, _ = self.assess(
+            facts(contents=workflow("jobs:\n  uses: trsdn/.github/.github/workflows/x.yml@main\n"))
+        )
+        self.assertEqual(drafted["S12"], "pass")
+
+    def test_a_branch_reference_outside_the_account_still_fails(self) -> None:
+        drafted, _ = self.assess(
+            facts(contents=workflow("jobs:\n  uses: other/.github/.github/workflows/x.yml@main\n"))
+        )
+        self.assertEqual(drafted["S12"], "fail")
+
+    # -- S11 ---------------------------------------------------------------
+
+    def test_a_workflow_without_permissions_is_partial_when_another_has_them(self) -> None:
+        contents = workflow("permissions:\n  contents: read\n", "a.yml")
+        contents.update(workflow("jobs:\n  build:\n", "b.yml"))
+        drafted, notes = self.assess(facts(contents=contents))
+        self.assertEqual(drafted["S11"], "partial")
+        self.assertIn("b.yml", notes)
+
+    def test_no_workflows_makes_the_workflow_criteria_not_applicable(self) -> None:
+        drafted, _ = self.assess(facts(contents={}))
+        self.assertEqual(drafted["S11"], "na")
+        self.assertEqual(drafted["S12"], "na")
+
+    # -- S13 ---------------------------------------------------------------
+
+    def test_an_untrusted_trigger_reading_a_secret_fails(self) -> None:
+        body = (
+            "on:\n  pull_request_target:\njobs:\n  a:\n    env:\n      T: ${{ secrets.DEPLOY }}\n"
+        )
+        drafted, notes = self.assess(facts(contents=workflow(body)))
+        self.assertEqual(drafted["S13"], "fail")
+        self.assertIn("DEPLOY", notes)
+
+    def test_an_untrusted_trigger_reading_no_secret_passes(self) -> None:
+        body = "on:\n  pull_request_target:\njobs:\n  a:\n    env:\n      T: ${{ secrets.GITHUB_TOKEN }}\n"
+        drafted, _ = self.assess(facts(contents=workflow(body)))
+        self.assertEqual(drafted["S13"], "pass")
+
+    # -- metadata ----------------------------------------------------------
+
+    def test_a_missing_topic_fails_b12(self) -> None:
+        drafted, _ = self.assess(facts(topics=[]))
+        self.assertEqual(drafted["B12"], "fail")
+
+    def test_a_missing_record_fails_b11(self) -> None:
+        drafted, _ = self.assess(facts(paths=["README.md"]))
+        self.assertEqual(drafted["B11"], "fail")
+
+    def test_a_private_repository_makes_the_public_profile_not_applicable(self) -> None:
+        drafted, _ = self.assess(facts(private=True))
+        self.assertEqual(drafted["P01"], "na")
+        self.assertEqual(drafted["P06"], "na")
+
+    def test_a_public_repository_without_a_licence_fails(self) -> None:
+        drafted, _ = self.assess(facts(licence=""))
+        self.assertEqual(drafted["P01"], "fail")
+        self.assertEqual(drafted["B03"], "fail")
+
+    def test_a_private_repository_without_a_licence_is_left_to_a_person(self) -> None:
+        """`B03` accepts an internal-use statement, which the script cannot read."""
+        drafted, _ = self.assess(facts(private=True, licence=""))
+        self.assertEqual(drafted["B03"], "unknown")
+
+    def test_a_security_policy_in_the_tree_is_not_reported_missing(self) -> None:
+        """The community profile has no `security` key, so absence proves nothing."""
+        drafted, _ = self.assess(
+            facts(paths=["SECURITY.md"], community_files={"readme": True, "license": True})
+        )
+        self.assertEqual(drafted["P03"], "unknown")
+
+    def test_no_security_policy_anywhere_fails(self) -> None:
+        drafted, _ = self.assess(
+            facts(paths=["README.md"], community_files={"readme": True, "license": True})
+        )
+        self.assertEqual(drafted["P03"], "fail")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Nine of 165 non-archived repositories carry the `trsdn-standard` topic. The
obstacle is not that the criteria are unclear — it is that starting a record
means transcribing 102 lines and then answering all of them. `B12` makes that
backlog visible on purpose, and nothing was making it smaller.

`scripts/assess.py` reads a repository through the GitHub API and drafts the
record plus the notes behind it.

**What it refuses to do is the design.** A script can prove that something is
absent; it cannot judge whether a README explains the purpose, whether tests
cover failure paths, or whether an issue form collects enough to triage. So it
decides only the criteria a fact settles and leaves the rest `unknown`:

| Decided | From |
|---|---|
| `B01`, `B03`, `B09`, `B11`, `B12` | Description, licence, archived flag, record file, topic |
| `P01`, `P02`, `P03`, `P04`, `P06`, `P10`, `P11` | Licence, community profile, intake templates — absence only |
| `S05`, `S09`, `S11`, `S12`, `S13` | Scanning status, required checks, `permissions`, `uses:` references, untrusted triggers |
| `G01` | `AGENTS.md` at the root |

`unknown` is not a result and `conformance.py --check` already rejects it. The
draft also keeps the `YYYY-MM-DD` placeholder, which the same check rejects. A
record is produced by a person looking at a repository, and a generated file
must not be able to pass for one. This removes the transcription, not the
assessment.

`S12` is implemented as the graduated table from 1.8.0, so an outside action
needs a SHA, a GitHub action may use a major-version tag, and a same-account
reusable workflow may use a branch.

## Related issue

None. Follows from the backlog `B12` exposes.

## Validation

- [x] The project's documented validation command succeeds locally
- [x] Tests were added or updated for behavior changes

18 new tests, 81 → 99. All run offline through the command line: collection and
decision are separated, so `--facts` decides from a saved file and no test
touches the network.

Two tests were confirmed load-bearing by reintroducing the bug they cover — the
`S12` same-account permission and the `P03` regression below — and both went
red as expected.

Run against two real repositories while developing: `trsdn/agent-trestle`
(13 decided) and `trsdn/OpenLens` (12 decided, and it correctly found no
conformance record, no topic, and secret scanning disabled).

## Impact

- User or operational risk: none to this repository. The script only reads, and
  it writes into a directory you name; it never edits a record in place.
- Security or privacy impact: read-only API access. The token comes from
  `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token`, and criteria whose evidence
  the token cannot see are left `unknown` rather than guessed at.
- Compatibility or migration impact: none. No criterion changed, so no version
  bump and no changelog entry — the standard document is untouched.

**One defect found while writing it, worth naming.** The first version reported
`P03` as a *failure* for a repository that does have a `SECURITY.md`, because it
read a `security` key from the community-profile API that the API does not emit.
Absence of a key is not absence of a policy. Left unfixed, that would have
written a wrong `fail` into every draft record. It is fixed and pinned by a test.

## Documentation

- [x] README, docs, and changelog are updated where the change is user-visible

[`docs/assessing.md`](../blob/main/docs/assessing.md) documents what it decides
and what it deliberately will not, and the adoption steps in the README now
start with the draft.
