### PR TITLE
fix: read the policy a repository inherits and the checks a ruleset requires

### DIFF
--- a/docs/assessing.md
+++ b/docs/assessing.md
@@ -28,10 +28,10 @@ assessment.
 | `B11` | Whether `.github/conformance.yml` exists |
 | `B12` | Whether the `trsdn-standard` topic is present |
 | `P02`, `P06` | The community profile GitHub reports, which counts inherited files |
-| `P03` | A security policy in the tree or recognised by GitHub, absence only |
+| `P03` | A security policy in the tree or inherited from the account, and whether private reporting is enabled |
 | `P04`, `P10`, `P11` | Whether any intake template exists, absence only |
 | `S05` | The secret scanning status, where the token can see it |
-| `S09` | Required status checks on the default branch, where the token can see it |
+| `S09` | Required status checks on the default branch, from rulesets and from branch protection |
 | `S11` | A `permissions` block in every workflow |
 | `S12` | Every `uses:` reference, against the graduated table in the standard |
 | `S13` | Untrusted triggers and the secrets they can reach |
@@ -42,9 +42,18 @@ Everything else is left to a person, and the notes file lists it.
 Two of these deserve their limits stated. `P10` and `P11` ask whether intake
 collects enough to act on, which the standard assesses on the information
 gathered rather than on headings; the script can only see that no template
-exists at all, so that is the only result it records. And `P03` is recorded as a
-failure only when no policy is found anywhere — the community profile API emits
-no `security` key, so its absence proves nothing.
+exists at all, so that is the only result it records.
+
+`P03` and `S09` are the two places where a fact is easy to read and easy to read
+wrongly, and both were wrong first. A public repository with no `SECURITY.md`
+inherits the account policy, so reading only its own tree reports a repository
+with a working private reporting channel as having none; and required checks now
+come from rulesets at least as often as from branch protection, so reading only
+branch protection reports a protected branch as unprotected. Each of those is
+worse than no answer, because a draft that is silent invites a look and a draft
+that is confidently wrong does not. Where the evidence cannot be read at all —
+an unreadable ruleset, a reporting setting the token cannot see — the criterion
+stays `unknown` rather than becoming a failure.
 
 Where the repository is private, the Public profile does not apply, and the
 script records `na` against every `P` criterion with that reason.

--- a/scripts/assess.py
+++ b/scripts/assess.py
@@ -146,6 +146,39 @@ class GitHub:
         return body.decode("utf-8", errors="replace")
 
 
+def required_checks_from_rulesets(client: GitHub, repository: str) -> dict:
+    """Read required checks from rulesets, which have replaced branch protection.
+
+    A repository can require checks through either mechanism, and increasingly
+    does so through rulesets alone. Reading only branch protection reports a
+    protected branch as unprotected, which is the worst kind of wrong answer: a
+    confident one. `readable` separates "no ruleset requires a check" from "the
+    rulesets could not be read", so that the second stays undecided.
+    """
+    status, rulesets = client.json(f"/repos/{repository}/rulesets?includes_parents=true")
+    if status != 200 or not isinstance(rulesets, list):
+        return {"readable": False, "checks": []}
+
+    checks: set[str] = set()
+    for summary in rulesets:
+        if not isinstance(summary, dict) or summary.get("target") != "branch":
+            continue
+        if summary.get("enforcement") != "active":
+            continue
+        detail_status, detail = client.json(f"/repos/{repository}/rulesets/{summary.get('id')}")
+        if detail_status != 200 or not isinstance(detail, dict):
+            continue
+        for rule in detail.get("rules") or []:
+            if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+                continue
+            parameters = rule.get("parameters") or {}
+            for entry in parameters.get("required_status_checks") or []:
+                context = (entry or {}).get("context")
+                if context:
+                    checks.add(context)
+    return {"readable": True, "checks": sorted(checks)}
+
+
 def collect(client: GitHub, repository: str) -> dict:
     """Read every fact the decisions below depend on, and nothing else."""
     status, meta = client.json(f"/repos/{repository}")
@@ -170,6 +203,20 @@ def collect(client: GitHub, repository: str) -> dict:
                 contents[path] = body
 
     protection_status, protection = client.json(f"/repos/{repository}/branches/{branch}/protection")
+    ruleset_checks = required_checks_from_rulesets(client, repository)
+    reporting_status, reporting = client.json(
+        f"/repos/{repository}/private-vulnerability-reporting"
+    )
+
+    owner = repository.split("/")[0]
+    inherited_policy = False
+    if not bool(meta.get("private")):
+        for path in ("SECURITY.md", ".github/SECURITY.md", "docs/SECURITY.md"):
+            found, _ = client.json(f"/repos/{owner}/.github/contents/{path}")
+            if found == 200:
+                inherited_policy = True
+                break
+
     licence = meta.get("license") or {}
     analysis = meta.get("security_and_analysis") or {}
     files = (profile or {}).get("files") or {} if isinstance(profile, dict) else {}
@@ -190,6 +237,13 @@ def collect(client: GitHub, repository: str) -> dict:
         "contents": contents,
         "community_files": {key: bool(value) for key, value in files.items()},
         "secret_scanning": (analysis.get("secret_scanning") or {}).get("status", ""),
+        "inherited_security_policy": inherited_policy,
+        "private_reporting": (
+            ""
+            if reporting_status != 200 or not isinstance(reporting, dict)
+            else ("enabled" if reporting.get("enabled") else "disabled")
+        ),
+        "ruleset_checks": ruleset_checks,
         "protection": {
             "visible": protection_status == 200,
             "required_checks": sorted(
@@ -334,12 +388,14 @@ def decide(facts: dict, catalog_ids: list[str]) -> dict[str, tuple[str, str]]:
     elif facts["secret_scanning"] == "disabled":
         decided["S05"] = ("fail", "secret scanning is disabled")
 
-    if facts["protection"]["visible"]:
-        checks = facts["protection"]["required_checks"]
+    ruleset = facts.get("ruleset_checks") or {"readable": False, "checks": []}
+    checks = sorted(set(facts["protection"]["required_checks"]) | set(ruleset["checks"]))
+    if checks:
+        decided["S09"] = ("pass", "required checks on the default branch: " + ", ".join(checks))
+    elif facts["protection"]["visible"] and ruleset["readable"]:
         decided["S09"] = (
-            ("pass", "required checks on the default branch: " + ", ".join(checks))
-            if checks
-            else ("fail", "the default branch is protected but requires no check")
+            "fail",
+            "the default branch is protected and no ruleset or protection requires a check",
         )
 
     forms = [path for path in paths if ISSUE_FORM.match(path)]
@@ -368,13 +424,27 @@ def decide(facts: dict, catalog_ids: list[str]) -> dict[str, tuple[str, str]]:
             if not missing
             else ("partial", "GitHub recognises no " + ", ".join(missing))
         )
-        if not community.get("security") and not any(
-            path.upper().endswith("SECURITY.MD") for path in paths
-        ):
-            decided["P03"] = (
-                "fail",
-                "no security policy in the tree and none recognised by GitHub",
-            )
+
+    policy_in_tree = any(path.upper().endswith("SECURITY.MD") for path in paths)
+    policy = policy_in_tree or bool(facts.get("inherited_security_policy"))
+    reporting = facts.get("private_reporting", "")
+    if not policy:
+        decided["P03"] = (
+            "fail",
+            "no security policy in the repository and none inherited from the account",
+        )
+    elif reporting == "disabled":
+        where = "the repository" if policy_in_tree else "the account"
+        decided["P03"] = (
+            "fail",
+            f"a policy is published by {where} but private vulnerability reporting is disabled",
+        )
+    elif reporting == "enabled":
+        where = "the repository" if policy_in_tree else "inherited from the account"
+        decided["P03"] = (
+            "pass",
+            f"private reporting is enabled and a policy is published ({where})",
+        )
 
     if facts["archived"]:
         decided["B09"] = ("pass", "the repository is archived, which is an intentional state")

--- a/tests/test_assess.py
+++ b/tests/test_assess.py
@@ -39,6 +39,9 @@ def facts(**overrides) -> dict:
         "contents": {},
         "community_files": {},
         "secret_scanning": "",
+        "inherited_security_policy": False,
+        "private_reporting": "",
+        "ruleset_checks": {"readable": False, "checks": []},
         "protection": {"visible": False, "required_checks": []},
     }
     base.update(overrides)
@@ -213,6 +216,46 @@ class AssessTests(unittest.TestCase):
             facts(paths=["README.md"], community_files={"readme": True, "license": True})
         )
         self.assertEqual(drafted["P03"], "fail")
+
+    def test_an_inherited_security_policy_is_not_reported_missing(self) -> None:
+        """A public repository inherits the account policy and satisfies `P03` through it."""
+        drafted, _ = self.assess(
+            facts(paths=["README.md"], inherited_security_policy=True, private_reporting="enabled")
+        )
+        self.assertEqual(drafted["P03"], "pass")
+
+    def test_a_policy_without_private_reporting_fails(self) -> None:
+        """`P03` asks for both. A published policy with public-only reporting is not enough."""
+        drafted, _ = self.assess(facts(paths=["SECURITY.md"], private_reporting="disabled"))
+        self.assertEqual(drafted["P03"], "fail")
+
+    def test_required_checks_in_a_ruleset_are_read(self) -> None:
+        """Rulesets have replaced branch protection, and reading only the latter reports
+        a protected branch as unprotected."""
+        drafted, notes = self.assess(
+            facts(ruleset_checks={"readable": True, "checks": ["build", "test"]})
+        )
+        self.assertEqual(drafted["S09"], "pass")
+        self.assertIn("build, test", notes)
+
+    def test_a_branch_with_no_required_check_anywhere_fails(self) -> None:
+        drafted, _ = self.assess(
+            facts(
+                protection={"visible": True, "required_checks": []},
+                ruleset_checks={"readable": True, "checks": []},
+            )
+        )
+        self.assertEqual(drafted["S09"], "fail")
+
+    def test_unreadable_rulesets_leave_the_branch_undecided(self) -> None:
+        """A token that cannot see the rulesets must not produce a confident failure."""
+        drafted, _ = self.assess(
+            facts(
+                protection={"visible": True, "required_checks": []},
+                ruleset_checks={"readable": False, "checks": []},
+            )
+        )
+        self.assertEqual(drafted["S09"], "unknown")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reassessing the eight recorded repositories against 1.9.0 was the first real use
of `assess.py`, and it produced four failures that were not failures.

**`P03`** was reported failing for `OpenSwitchr` and `PtionsPlus`, both of which
have a working private reporting channel. A public repository with no
`SECURITY.md` of its own inherits the account policy, and `trsdn/.github`
publishes one — `https://github.com/trsdn/OpenSwitchr/security/policy` renders it.
Reading only the repository's own tree answered a different question than the
criterion asks. The community profile cannot settle it either: its
`security_policy` key is absent for *every* repository in this account,
including those that do publish their own policy.

Since `P03` asks for a documented policy *and* private reporting, and reporting
is readable, it is now read:

| Policy | Private reporting | Result |
|---|---|---|
| Local or inherited | enabled | `pass` |
| Local or inherited | disabled | `fail` |
| Local or inherited | unreadable | `unknown` |
| None anywhere | any | `fail` |

**`S09`** was reported failing for `MistralDocAI-mcp` and `oft-eml-converter-mac`,
whose default branches do require checks — through an active ruleset rather than
through branch protection. Rulesets have largely replaced branch protection, and
reading only the latter reports a protected branch as unprotected. Checks are now
taken from both, and an unreadable ruleset list leaves the criterion `unknown`
rather than failing it.

Both defects produced *confident wrong answers*, which are worse than no answer.
A draft that leaves a criterion undecided invites someone to look at the
repository; one that states a failure invites them to trust it.

After the fix, all four repositories draft `P03: pass` and `S09: pass`, and the
decided count rises from 12–13 to 13–14 of 102.

## Related issue

None. Found by using the script from #51 against the recorded repositories.

## Validation

- [x] The project's documented validation command succeeds locally
- [x] Tests were added or updated for behavior changes

Five new tests, 99 to 104, covering the inherited policy, a policy with
reporting disabled, checks from a ruleset, no check from either mechanism, and
an unreadable ruleset list. Reverting each fix in turn was confirmed to turn
exactly one of them red.

## Impact

- User or operational risk: none. The script only reads.
- Security or privacy impact: two additional read-only endpoints —
  `/rulesets` and `/private-vulnerability-reporting` — and a content lookup
  against the account `.github` repository. Nothing new is written or exposed.
- Compatibility or migration impact: none. No criterion changed, so no version
  bump and no changelog entry.

## Documentation

- [x] README, docs, and changelog are updated where the change is user-visible

`docs/assessing.md` records what each criterion is now decided from, and why
these two are the places where a fact is easy to read and easy to read wrongly.
